### PR TITLE
Use comma-separation

### DIFF
--- a/meta.xml
+++ b/meta.xml
@@ -1,5 +1,5 @@
 <archive xmlns="http://rs.tdwg.org/dwc/text/" metadata="eml.xml">
-  <core encoding="utf-8" fieldsTerminatedBy=";" linesTerminatedBy="\n" fieldsEnclosedBy="&quot;" ignoreHeaderLines="1" rowType="http://rs.tdwg.org/dwc/terms/Taxon">
+  <core encoding="utf-8" fieldsTerminatedBy="," linesTerminatedBy="\n" fieldsEnclosedBy="&quot;" ignoreHeaderLines="1" rowType="http://rs.tdwg.org/dwc/terms/Taxon">
     <files>
       <location>patch.csv</location>
     </files>

--- a/patch.csv
+++ b/patch.csv
@@ -1,138 +1,138 @@
-taxonID;parentNameUsageID;acceptedNameUsageID;originalNameUsageID;taxonRank;taxonomicStatus;scientificName;nameAccordingTo;namePublishedInYear;namePublishedIn;namePublishedInID;nomenclaturalStatus;dc:references;typification;taxonRemarks
-k1;;;;kingdom;;Animalia;;;;;;;;
-k2;;;;kingdom;;Plantae;;;;;;;;
-k3;;;;kingdom;;Fungi;;;;;;;;
-k4;;;;kingdom;;Protozoa;;;;;;;;
-k5;;;;kingdom;;Chromista;;;;;;;;
-p1;k1;;;phylum;;Arthropoda;;;;;;;;
-p2;k1;;;phylum;;Mollusca;;;;;;;;
-p3;k3;;;phylum;;Ascomycota;;;;;;;;
-p4;k1;;;phylum;;Ctenophora;;;;;;;;
-p5;k2;;;phylum;;Chlorophyta;;;;;;;;
-p6;k1;;;phylum;;Chordata;;;;;;;;
-p7;k2;;;phylum;;Tracheophyta;;;;;;;;
-p7-s1;;p7;;phylum;synonym;Psilotophyta;;;;;;;;
-p7-s2;;p7;;phylum;synonym;Microphyllophyta;;;;;;;;
-p7-s3;;p7;;phylum;synonym;Arthrophyta;;;;;;;;
-p7-s4;;p7;;phylum;synonym;Pterophyta;;;;;;;;
-p7-s5;;p7;;phylum;synonym;Cycadophyta;;;;;;;;
-p7-s6;;p7;;phylum;synonym;Ginkgophyta;;;;;;;;
-p7-s7;;p7;;phylum;synonym;Coniferophyta;;;;;;;;
-p7-s8;;p7;;phylum;synonym;Gnetophyta;;;;;;;;
-p7-s9;;p7;;phylum;synonym;Magnoliophyta;;;;;;;;
-p7-s10;;p7;;phylum;synonym;Equisetophyta;;;;;;;;
-p7-s11;;p7;;phylum;synonym;Lycopodiophyta;;;;;;;;
-p7-s12;;p7;;phylum;synonym;Polypodiophyta;;;;;;;;
-p7-s13;;p7;;subkingdom;synonym;Tracheobionta;;;;;;;;
-p7-s14;;p7;;phylum;synonym;Psilophyta;;;;;;;;
-p7-s15;;p7;;phylum;synonym;Pteridophyta;;;;;;;;
-p7-s16;;p7;;subphylum;synonym;Pteridophytina;;;;;;;;
-p8;k2;;;phylum;;Marchantiophyta;;;;;;;;
-p8-s1;;p8;;phylum;synonym;Hepaticae;;;;;;;;
-p8-s2;;p8;;phylum;synonym;Hepatophyta;;;;;;;;
-p8-s3;;p8;;subphylum;synonym;Marchantiophytina;;;;;;;;
-p9;k2;;;phylum;;Bryophyta;;;;;;;;
-p9-s1;;p9;;phylum;synonym;Musci;;;;;;;;
-p9-s2;;p9;;subphylum;synonym;Bryophytina;;;;;;;;
-p10;k5;;;phylum;;Cryptophyta;;;;;;;;
-p10-s1;;p10;;phylum;synonym;Cryptista;;;;;;;;
-24;;k4;;subphylum;synonym;Radiolaria;wikipedia;;;;;;;A subphylum hard to map to the CoL tree. Protozoa is a bit high, but is the best single match
-c1;p1;;;class;;Insecta;;;;;;;;
-c2;p2;;;class;;Gastropoda;;;;;;;;
-c3;p3;;;class;;Dothideales;;;;;;;;
-c4;p4;;;class;;Tentaculata;;;;;;;;
-c6;p6;;;class;;Aves;;;;;;;;
-c7;p7;;;class;;Lycopodiopsida;;;;;;;;
-c8;p3;;;class;;Leotiomycetes;;;;;;;;
-c9;p1;;;class;;Arachnida;;;;;;;;
-c10;k4;;;class;accepted;Acantharia;CoL;;;;;;;
-c11;p6;;;class;;Amphibia;;;;;;;;
-c12;k1;;;class;;Clitellata;;;;;;;;
-c13;;c12;;class;;Oligochaeta;;;;;;;;
-c14;k1;;;class;;Malacostraca;;;;;;;;
-o1;c1;;;order;;Coleoptera;;;;;;;;
-o3;c1;;;order;;Hymenoptera;;;;;;;;
-o4;c1;;;order;;Hemiptera;;;;;;;;
-o5;c3;;;order;;Coccoideaceae;;;;;;;;
-o6;c4;;;order;;Lobata;;;;;;;;
-o8;c8;;;order;;Helotiales;;;;;;;;
-o9;c9;;;order;;Pseudoscorpiones;CoL;;;;;;;
-o10;;o9;;order;synonym;Pseudoscorpionida;Wikipedia;;;;;https://en.wikipedia.org/wiki/Pseudoscorpion;;
-o11;;o9;;order;synonym;Chelonethida;Wikipedia;;;;;https://en.wikipedia.org/wiki/Pseudoscorpion;;
-o12;c2;;;order;;Stylommatophora;ITIS;;;;;http://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&search_value=76755;;
-o13;c2;;;order;;Littorinimorpha;;;;;;http://www.catalogueoflife.org/col/browse/tree/id/4f3b1133c474f0b6a140c2c034c4662a;;
-o14;;o13;;order;;Heteropoda;;;;;;https://en.wikipedia.org/wiki/Pterotracheoidea;;
-sf1;o4;;;superfamily;accepted;Coccoidea;CoL;;;;;;;
-f1;o1;;;family;;Hydraenidae;;;;;;;;
-f2;o12;;;family;;Amastridae;;;;;;;;
-f3;c2;;;family;;Pyramidellidae;;;;;;;;
-f4;p5;;;family;;Ulvaceae;;;;;;;;
-f5;o3;;;family;;Vespidae;;;;;;;;
-f6;o8;;;family;;Helotiaceae;;;;;;;;
-f7;c11;;;family;;Dendrobatidae;;;;;;;;
-f8;k2;;;family;;Asteraceae;;;;;;;;
-f9;c1;;;family;;Cimeliidae;;;;;;;;
-f10;;f9;;family;;Axiidae Rebel;;;;;;;;
-f11;c14;;;family;;Axiidae Huxley;;;;;;;;
-f12;;f8;;family;synonym;Compositae;;;;;;;;
-f13;k2;;;family;accepted;Fabaceae;;;;;;;;
-f14;;f13;;family;synonym;Leguminosae;;;;;;;;
-1;f1;;;species;accepted;Hydraena truncata Rey, 1885;ITIS;;;;;http://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&search_value=815716;;Provisionally added until it becomes available via ITIS or FaunaEuropaea
-2;f2;;;species;accepted;Amastra affinis (Newcomb, 1854);BishopMuseum;;;;;http://nsdb.bishopmuseum.org/?w=BPBM&explst=tr&cols=10&rpp=1000&pge=1&id=1519640147;;
-3;;2;;species;junior synonym;Achatinella goniostoma;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-4;;2;;species;junior synonym;Achatinella pupoidea;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-5;;2;;species;junior synonym;Amastra abberans;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-6;;2;;subspecies;junior synonym;Amastra affinis subsp. subpulla;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-7;;2;;variety;junior synonym;Amastra affinis var. bigener;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-8;;2;;variety;junior synonym;Amastra affinis var. cinderella;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-9;;2;;variety;junior synonym;Amastra bigener var. abberans;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-10;;2;;species;junior synonym;Amastra bigener;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-12;;2;;species;junior synonym;Amastra cinderella;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-13;;2;;species;junior synonym;Amastra goniostoma;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-14;;2;;species;junior synonym;Amastra pupoidea;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-15;;2;;species;junior synonym;Amastra rustica;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-17;;2;;species;junior synonym;Amastra subpulla;BishopMuseum;;;;;;;following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p.
-20;f3;;;genus;accepted;Belonidium Cossmann, 1892;IRMNG;1892;J. Conchyliol., 40, 350.;;;;;
-21;;20;;genus;synonym;Anisocycla Cossmann, 1888;IRMNG;1888;Ann. Soc. malac. Belgique, 23, Mém., 108.;;nomen nudum;;;
-22;o3;;;genus;accepted;Dacnusa Haliday, 1833;ITIS;;;;;;;
-23;;22;;genus;synonym;Radiolaria Provancher, 1886;ITIS;;;;;;;
-26;o5;;;genus;accepted;Coccoidea;CoL;;;;;;;
-28;p3;;;genus;accepted;Acantharia;IF;;;;;;;
-30;f4;;;genus;accepted;Lobata;;;;;;;;
-31;c6;;;species;accepted;Monticola erythronotus;IUCN;;;;;;;
-32;c6;31;;species;synonym;Monticola erythronota;Clements Checklist;;;;;;;
-33;f5;;;species;accepted;Vespula alascensis (Packard, 1870);Peter de Vries;;;;;http://digitallibrary.amnh.org/dspace/handle/2246/6074;;Carpenter & Glare 1956: Misidentification of Vespula alascensis as V. vulgaris in North America.
-34;f5;;;species;accepted;Hypodynerus anae Barerra, 2011;Barerra;2011;Boletín de la Sociedad Entomológica  Aragonesa, 48: 157-162.;;;http://www.insectos.cl/pdf/barrera-medina-2011%20157%20162%20BSEA%2048%20Avispa%20alfarera%20Chile.pdf;;notified by personal author email. See also http://www.vespidae.be/Eumeninae/Hypodynerus_anae.htm
-35;c7;36;;species;synonym;Stigmaria fucoides;Sven Ziepe;;;;misspelling;;;notified by Sven Ziepe, pandora.be
-36;c7;;;species;accepted;Stigmaria ficoides;Sven Ziepe;;;;;;;
-37;f6;;;species;accepted;Hymenoscyphus pseudoalbidus V. Queloz, C.R. Grünig, R. Berndt, T. Kowalski, T.N. Sieber & O. Holdenrieder;MycoBank;2010;;http://www.mycobank.org/MB/542015;;;;notified by personal email from Andrin Gross
-38;f7;;;genus;accepted;Andinobates Twomey, Brown, Amézquita, and Mejía-Vargas, 2011;;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083: 20;;;;Type species: Dendrobates bombetes Myers and Daly, 1980, by original designation.; notified by Ángela Suárez-Mayorga, see http://dev.gbif.org/issues/browse/POR-2030
-39;38;;53;species;;Andinobates abditus (Myers and Daly, 1976);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083: 36.;http://dendrobates.org/articles/Myers&Daly1976_D.abditus.pdf;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-abditus;;
-40;38;;54;species;;Andinobates altobueyensis (Silverstone, 1975);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083: 30.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-altobueyensis;;
-41;38;;;species;;Andinobates bombetes (Myers and Daly, 1980);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-bombetes;;
-42;38;;;species;;Andinobates cassidyhornae Amézquita, Márquez, Mejía-Vargas, Kahn, Suárez, and Mazariegos, 2013;;2013;Amézquita, Márquez, Mejía-Vargas, Kahn, Suárez, and Mazariegos, 2013, Zootaxa, 3620: 168.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-cassidyhornae;;
-43;38;;55;species;;Andinobates claudiae (Jungfer, Lötters, and Jörgens, 2000);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-claudiae;;
-44;38;;56;species;;Andinobates daleswansoni (Rueda-Almonacid, Rada, Sánchez-Pacheco, Velásquez-Álvarez, and Quevedo-Gil, 2006);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-daleswansoni;;
-45;38;;57;species;;Andinobates dorisswansonae (Rueda-Almonacid, Rada, Sánchez-Pacheco, Velásquez-Álvarez, and Quevedo-Gil, 2006);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-dorisswansonae;;
-46;38;;58;species;;Andinobates fulguritus (Silverstone, 1975);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-fulguritus;;
-47;38;;;species;;Andinobates geminisae Batista, Jaramillo, Ponce, and Crawford, 2014;;2014;Batista, Abel, César J. A., Marcos Ponce & Andrew J. Crawford. 2014 A new species of Andinobates (Amphibia: Anura: Dendrobatidae) from west central Panama. Zootaxa 3866(3): 333–352.;http://dx.doi.org/10.11646/zootaxa.3866.3.2;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-geminisae;;
-48;38;;;species;;Andinobates minutus (Shreve, 1935);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-minutus;;
-49;38;;;species;;Andinobates opisthomelas (Boulenger, 1899);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-opisthomelas;;
-50;38;;;species;;Andinobates tolimensis (Bernal-Bautista, Luna-Mora, Gallego, and Quevedo-Gil, 2007);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-tolimensis;;
-51;38;;;species;;Andinobates viridis (Myers and Daly, 1976);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-viridis;;
-52;38;;;species;;Andinobates virolinensis (Ruiz-Carranza and Ramírez-Pinilla, 1992);;2011;Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.;;;http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-virolinensis;;
-53;;39;;species;;Dendrobates abditus Myers and Daly, 1976;;1976;Occas. Pap. Mus. Nat. Hist. Univ. Kansas, 59: 1;;;;;
-54;;40;;species;;Dendrobates altobueyensis Silverstone, 1975;;1975;;;;;;
-55;;43;;species;;Dendrobates claudiae Jungfer, Lötters, and Jörgens, 2000;;2000;Herpetofauna, Weinstadt, 22: 12.;;;;;
-56;;44;;species;;Dendrobates daleswansoni Rueda-Almonacid, Rada, Sánchez-Pacheco, Velásquez-Álvarez, and Quevedo-Gil, 2006;;2006;Zootaxa, 1259: 41.;;;;;
-57;;45;;species;;Dendrobates dorisswansoni Rueda-Almonacid, Rada, Sánchez-Pacheco, Velásquez-Álvarez, and Quevedo-Gil, 2006;;2006;Zootaxa, 1259: 48.;;;;;
-58;;46;;species;;Dendrobates fulguritus Silverstone, 1975;;1975;Sci. Bull. Nat. Hist. Mus. Los Angeles Co., 21: 28. ;;;;;
-59;f8;;;species;;Jacobaea vulgaris Gaertn.;;1791;Fruct. Sem. Pl. 2: 445. 1791;;;;;
-60;59;;;subspecies;;Jacobaea vulgaris subsp. gotlandica (Neuman) B.Nord.;;2006;Compositae Newslett. 44: 12 (2006);;;http://www.actaplantarum.org/flora/flora_info.php?id=9392;;
-61;59;;;subspecies;;Jacobaea vulgaris subsp. dunensis (Dumort.) Pelser & Meijden;;2005;Heukels' Fl. Nederland 677. 2005;;;http://www.theplantlist.org/tpl1.1/record/gcc-54851;;
-62;;60;;variety;;Senecio jacobaea L. var. gotlandicus Neuman;;1901;Sver. Fl .: 26 (1901);;;http://botanicaserbica.bio.bg.ac.rs/arhiva/pdf/2012_36_2_570_full.pdf;;
-63;p3;;;species;;Tephromela siphulodes Poelt & Grube;;1993;Nova Hedwigia 57(1-2): 9 (1993);;;http://www.indexfungorum.org/names/NamesRecord.asp?RecordID=360652;;
-64;;63;;species;;Tephromela siphuloides Poelt & Grube;;;;;;http://www.biodiversity.no/ScientificName/75131;;
-65;f8;;;species;accepted;Ambrosia artemisiifolia L.;;;;;;http://www.theplantlist.org/tpl1.1/record/gcc-20460;;
-66;f8;;;species;accepted;Ambrosia polystachya DC.;;;;;;;;
-67;;66;;species;synonym;Ambrosia artemisiifolia Besser;;;;;;http://www.theplantlist.org/tpl1.1/record/gcc-142227;;illegitimate name
+taxonID,parentNameUsageID,acceptedNameUsageID,originalNameUsageID,taxonRank,taxonomicStatus,scientificName,nameAccordingTo,namePublishedInYear,namePublishedIn,namePublishedInID,nomenclaturalStatus,dc:references,typification,taxonRemarks
+k1,,,,kingdom,,Animalia,,,,,,,,
+k2,,,,kingdom,,Plantae,,,,,,,,
+k3,,,,kingdom,,Fungi,,,,,,,,
+k4,,,,kingdom,,Protozoa,,,,,,,,
+k5,,,,kingdom,,Chromista,,,,,,,,
+p1,k1,,,phylum,,Arthropoda,,,,,,,,
+p2,k1,,,phylum,,Mollusca,,,,,,,,
+p3,k3,,,phylum,,Ascomycota,,,,,,,,
+p4,k1,,,phylum,,Ctenophora,,,,,,,,
+p5,k2,,,phylum,,Chlorophyta,,,,,,,,
+p6,k1,,,phylum,,Chordata,,,,,,,,
+p7,k2,,,phylum,,Tracheophyta,,,,,,,,
+p7-s1,,p7,,phylum,synonym,Psilotophyta,,,,,,,,
+p7-s2,,p7,,phylum,synonym,Microphyllophyta,,,,,,,,
+p7-s3,,p7,,phylum,synonym,Arthrophyta,,,,,,,,
+p7-s4,,p7,,phylum,synonym,Pterophyta,,,,,,,,
+p7-s5,,p7,,phylum,synonym,Cycadophyta,,,,,,,,
+p7-s6,,p7,,phylum,synonym,Ginkgophyta,,,,,,,,
+p7-s7,,p7,,phylum,synonym,Coniferophyta,,,,,,,,
+p7-s8,,p7,,phylum,synonym,Gnetophyta,,,,,,,,
+p7-s9,,p7,,phylum,synonym,Magnoliophyta,,,,,,,,
+p7-s10,,p7,,phylum,synonym,Equisetophyta,,,,,,,,
+p7-s11,,p7,,phylum,synonym,Lycopodiophyta,,,,,,,,
+p7-s12,,p7,,phylum,synonym,Polypodiophyta,,,,,,,,
+p7-s13,,p7,,subkingdom,synonym,Tracheobionta,,,,,,,,
+p7-s14,,p7,,phylum,synonym,Psilophyta,,,,,,,,
+p7-s15,,p7,,phylum,synonym,Pteridophyta,,,,,,,,
+p7-s16,,p7,,subphylum,synonym,Pteridophytina,,,,,,,,
+p8,k2,,,phylum,,Marchantiophyta,,,,,,,,
+p8-s1,,p8,,phylum,synonym,Hepaticae,,,,,,,,
+p8-s2,,p8,,phylum,synonym,Hepatophyta,,,,,,,,
+p8-s3,,p8,,subphylum,synonym,Marchantiophytina,,,,,,,,
+p9,k2,,,phylum,,Bryophyta,,,,,,,,
+p9-s1,,p9,,phylum,synonym,Musci,,,,,,,,
+p9-s2,,p9,,subphylum,synonym,Bryophytina,,,,,,,,
+p10,k5,,,phylum,,Cryptophyta,,,,,,,,
+p10-s1,,p10,,phylum,synonym,Cryptista,,,,,,,,
+24,,k4,,subphylum,synonym,Radiolaria,wikipedia,,,,,,,"A subphylum hard to map to the CoL tree. Protozoa is a bit high, but is the best single match"
+c1,p1,,,class,,Insecta,,,,,,,,
+c2,p2,,,class,,Gastropoda,,,,,,,,
+c3,p3,,,class,,Dothideales,,,,,,,,
+c4,p4,,,class,,Tentaculata,,,,,,,,
+c6,p6,,,class,,Aves,,,,,,,,
+c7,p7,,,class,,Lycopodiopsida,,,,,,,,
+c8,p3,,,class,,Leotiomycetes,,,,,,,,
+c9,p1,,,class,,Arachnida,,,,,,,,
+c10,k4,,,class,accepted,Acantharia,CoL,,,,,,,
+c11,p6,,,class,,Amphibia,,,,,,,,
+c12,k1,,,class,,Clitellata,,,,,,,,
+c13,,c12,,class,,Oligochaeta,,,,,,,,
+c14,k1,,,class,,Malacostraca,,,,,,,,
+o1,c1,,,order,,Coleoptera,,,,,,,,
+o3,c1,,,order,,Hymenoptera,,,,,,,,
+o4,c1,,,order,,Hemiptera,,,,,,,,
+o5,c3,,,order,,Coccoideaceae,,,,,,,,
+o6,c4,,,order,,Lobata,,,,,,,,
+o8,c8,,,order,,Helotiales,,,,,,,,
+o9,c9,,,order,,Pseudoscorpiones,CoL,,,,,,,
+o10,,o9,,order,synonym,Pseudoscorpionida,Wikipedia,,,,,https://en.wikipedia.org/wiki/Pseudoscorpion,,
+o11,,o9,,order,synonym,Chelonethida,Wikipedia,,,,,https://en.wikipedia.org/wiki/Pseudoscorpion,,
+o12,c2,,,order,,Stylommatophora,ITIS,,,,,http://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&search_value=76755,,
+o13,c2,,,order,,Littorinimorpha,,,,,,http://www.catalogueoflife.org/col/browse/tree/id/4f3b1133c474f0b6a140c2c034c4662a,,
+o14,,o13,,order,,Heteropoda,,,,,,https://en.wikipedia.org/wiki/Pterotracheoidea,,
+sf1,o4,,,superfamily,accepted,Coccoidea,CoL,,,,,,,
+f1,o1,,,family,,Hydraenidae,,,,,,,,
+f2,o12,,,family,,Amastridae,,,,,,,,
+f3,c2,,,family,,Pyramidellidae,,,,,,,,
+f4,p5,,,family,,Ulvaceae,,,,,,,,
+f5,o3,,,family,,Vespidae,,,,,,,,
+f6,o8,,,family,,Helotiaceae,,,,,,,,
+f7,c11,,,family,,Dendrobatidae,,,,,,,,
+f8,k2,,,family,,Asteraceae,,,,,,,,
+f9,c1,,,family,,Cimeliidae,,,,,,,,
+f10,,f9,,family,,Axiidae Rebel,,,,,,,,
+f11,c14,,,family,,Axiidae Huxley,,,,,,,,
+f12,,f8,,family,synonym,Compositae,,,,,,,,
+f13,k2,,,family,accepted,Fabaceae,,,,,,,,
+f14,,f13,,family,synonym,Leguminosae,,,,,,,,
+1,f1,,,species,accepted,"Hydraena truncata Rey, 1885",ITIS,,,,,http://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&search_value=815716,,Provisionally added until it becomes available via ITIS or FaunaEuropaea
+2,f2,,,species,accepted,"Amastra affinis (Newcomb, 1854)",BishopMuseum,,,,,http://nsdb.bishopmuseum.org/?w=BPBM&explst=tr&cols=10&rpp=1000&pge=1&id=1519640147,,
+3,,2,,species,junior synonym,Achatinella goniostoma,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+4,,2,,species,junior synonym,Achatinella pupoidea,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+5,,2,,species,junior synonym,Amastra abberans,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+6,,2,,subspecies,junior synonym,Amastra affinis subsp. subpulla,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+7,,2,,variety,junior synonym,Amastra affinis var. bigener,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+8,,2,,variety,junior synonym,Amastra affinis var. cinderella,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+9,,2,,variety,junior synonym,Amastra bigener var. abberans,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+10,,2,,species,junior synonym,Amastra bigener,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+12,,2,,species,junior synonym,Amastra cinderella,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+13,,2,,species,junior synonym,Amastra goniostoma,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+14,,2,,species,junior synonym,Amastra pupoidea,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+15,,2,,species,junior synonym,Amastra rustica,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+17,,2,,species,junior synonym,Amastra subpulla,BishopMuseum,,,,,,,"following Cowie, R. H., N. L. Evenhuis & C. C. Christensen. 1995. Catalog of the native land and freshwater molluscs of the Hawaiian Islands. Backhuys Publishers, Leiden. vi+248 p."
+20,f3,,,genus,accepted,"Belonidium Cossmann, 1892",IRMNG,1892,"J. Conchyliol., 40, 350.",,,,,
+21,,20,,genus,synonym,"Anisocycla Cossmann, 1888",IRMNG,1888,"Ann. Soc. malac. Belgique, 23, Mém., 108.",,nomen nudum,,,
+22,o3,,,genus,accepted,"Dacnusa Haliday, 1833",ITIS,,,,,,,
+23,,22,,genus,synonym,"Radiolaria Provancher, 1886",ITIS,,,,,,,
+26,o5,,,genus,accepted,Coccoidea,CoL,,,,,,,
+28,p3,,,genus,accepted,Acantharia,IF,,,,,,,
+30,f4,,,genus,accepted,Lobata,,,,,,,,
+31,c6,,,species,accepted,Monticola erythronotus,IUCN,,,,,,,
+32,c6,31,,species,synonym,Monticola erythronota,Clements Checklist,,,,,,,
+33,f5,,,species,accepted,"Vespula alascensis (Packard, 1870)",Peter de Vries,,,,,http://digitallibrary.amnh.org/dspace/handle/2246/6074,,Carpenter & Glare 1956: Misidentification of Vespula alascensis as V. vulgaris in North America.
+34,f5,,,species,accepted,"Hypodynerus anae Barerra, 2011",Barerra,2011,"Boletín de la Sociedad Entomológica  Aragonesa, 48: 157-162.",,,http://www.insectos.cl/pdf/barrera-medina-2011%20157%20162%20BSEA%2048%20Avispa%20alfarera%20Chile.pdf,,notified by personal author email. See also http://www.vespidae.be/Eumeninae/Hypodynerus_anae.htm
+35,c7,36,,species,synonym,Stigmaria fucoides,Sven Ziepe,,,,misspelling,,,"notified by Sven Ziepe, pandora.be"
+36,c7,,,species,accepted,Stigmaria ficoides,Sven Ziepe,,,,,,,
+37,f6,,,species,accepted,"Hymenoscyphus pseudoalbidus V. Queloz, C.R. Grünig, R. Berndt, T. Kowalski, T.N. Sieber & O. Holdenrieder",MycoBank,2010,,http://www.mycobank.org/MB/542015,,,,notified by personal email from Andrin Gross
+38,f7,,,genus,accepted,"Andinobates Twomey, Brown, Amézquita, and Mejía-Vargas, 2011",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083: 20",,,,"Type species: Dendrobates bombetes Myers and Daly, 1980, by original designation."," notified by Ángela Suárez-Mayorga, see http://dev.gbif.org/issues/browse/POR-2030"
+39,38,,53,species,,"Andinobates abditus (Myers and Daly, 1976)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083: 36.",http://dendrobates.org/articles/Myers&Daly1976_D.abditus.pdf,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-abditus,,
+40,38,,54,species,,"Andinobates altobueyensis (Silverstone, 1975)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083: 30.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-altobueyensis,,
+41,38,,,species,,"Andinobates bombetes (Myers and Daly, 1980)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-bombetes,,
+42,38,,,species,,"Andinobates cassidyhornae Amézquita, Márquez, Mejía-Vargas, Kahn, Suárez, and Mazariegos, 2013",,2013,"Amézquita, Márquez, Mejía-Vargas, Kahn, Suárez, and Mazariegos, 2013, Zootaxa, 3620: 168.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-cassidyhornae,,
+43,38,,55,species,,"Andinobates claudiae (Jungfer, Lötters, and Jörgens, 2000)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-claudiae,,
+44,38,,56,species,,"Andinobates daleswansoni (Rueda-Almonacid, Rada, Sánchez-Pacheco, Velásquez-Álvarez, and Quevedo-Gil, 2006)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-daleswansoni,,
+45,38,,57,species,,"Andinobates dorisswansonae (Rueda-Almonacid, Rada, Sánchez-Pacheco, Velásquez-Álvarez, and Quevedo-Gil, 2006)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-dorisswansonae,,
+46,38,,58,species,,"Andinobates fulguritus (Silverstone, 1975)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-fulguritus,,
+47,38,,,species,,"Andinobates geminisae Batista, Jaramillo, Ponce, and Crawford, 2014",,2014,"Batista, Abel, César J. A., Marcos Ponce & Andrew J. Crawford. 2014 A new species of Andinobates (Amphibia: Anura: Dendrobatidae) from west central Panama. Zootaxa 3866(3): 333–352.",http://dx.doi.org/10.11646/zootaxa.3866.3.2,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-geminisae,,
+48,38,,,species,,"Andinobates minutus (Shreve, 1935)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-minutus,,
+49,38,,,species,,"Andinobates opisthomelas (Boulenger, 1899)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-opisthomelas,,
+50,38,,,species,,"Andinobates tolimensis (Bernal-Bautista, Luna-Mora, Gallego, and Quevedo-Gil, 2007)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-tolimensis,,
+51,38,,,species,,"Andinobates viridis (Myers and Daly, 1976)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-viridis,,
+52,38,,,species,,"Andinobates virolinensis (Ruiz-Carranza and Ramírez-Pinilla, 1992)",,2011,"Brown, Twomey, Amézquita, Souza, Caldwell, Lötters, von May, Melo-Sampaio, Mejía-Vargas, Pérez-Peña, Pepper, Poelman, Sanchez-Rodriguez, and Summers, 2011, Zootaxa, 3083.",,,http://research.amnh.org/vz/herpetology/amphibia/index.php//Amphibia/Anura/Dendrobatidae/Dendrobatinae/Andinobates/Andinobates-virolinensis,,
+53,,39,,species,,"Dendrobates abditus Myers and Daly, 1976",,1976,"Occas. Pap. Mus. Nat. Hist. Univ. Kansas, 59: 1",,,,,
+54,,40,,species,,"Dendrobates altobueyensis Silverstone, 1975",,1975,,,,,,
+55,,43,,species,,"Dendrobates claudiae Jungfer, Lötters, and Jörgens, 2000",,2000,"Herpetofauna, Weinstadt, 22: 12.",,,,,
+56,,44,,species,,"Dendrobates daleswansoni Rueda-Almonacid, Rada, Sánchez-Pacheco, Velásquez-Álvarez, and Quevedo-Gil, 2006",,2006,"Zootaxa, 1259: 41.",,,,,
+57,,45,,species,,"Dendrobates dorisswansoni Rueda-Almonacid, Rada, Sánchez-Pacheco, Velásquez-Álvarez, and Quevedo-Gil, 2006",,2006,"Zootaxa, 1259: 48.",,,,,
+58,,46,,species,,"Dendrobates fulguritus Silverstone, 1975",,1975,"Sci. Bull. Nat. Hist. Mus. Los Angeles Co., 21: 28. ",,,,,
+59,f8,,,species,,Jacobaea vulgaris Gaertn.,,1791,Fruct. Sem. Pl. 2: 445. 1791,,,,,
+60,59,,,subspecies,,Jacobaea vulgaris subsp. gotlandica (Neuman) B.Nord.,,2006,Compositae Newslett. 44: 12 (2006),,,http://www.actaplantarum.org/flora/flora_info.php?id=9392,,
+61,59,,,subspecies,,Jacobaea vulgaris subsp. dunensis (Dumort.) Pelser & Meijden,,2005,Heukels' Fl. Nederland 677. 2005,,,http://www.theplantlist.org/tpl1.1/record/gcc-54851,,
+62,,60,,variety,,Senecio jacobaea L. var. gotlandicus Neuman,,1901,Sver. Fl .: 26 (1901),,,http://botanicaserbica.bio.bg.ac.rs/arhiva/pdf/2012_36_2_570_full.pdf,,
+63,p3,,,species,,Tephromela siphulodes Poelt & Grube,,1993,Nova Hedwigia 57(1-2): 9 (1993),,,http://www.indexfungorum.org/names/NamesRecord.asp?RecordID=360652,,
+64,,63,,species,,Tephromela siphuloides Poelt & Grube,,,,,,http://www.biodiversity.no/ScientificName/75131,,
+65,f8,,,species,accepted,Ambrosia artemisiifolia L.,,,,,,http://www.theplantlist.org/tpl1.1/record/gcc-20460,,
+66,f8,,,species,accepted,Ambrosia polystachya DC.,,,,,,,,
+67,,66,,species,synonym,Ambrosia artemisiifolia Besser,,,,,,http://www.theplantlist.org/tpl1.1/record/gcc-142227,,illegitimate name


### PR DESCRIPTION
Currently, the data file `patch.csv` doesn't [render nicely on GitHub](https://github.com/gbif/backbone-patch/blob/fe911afc22dd6470c3141ab8b34e2acbf442e1b0/patch.csv), making it harder to read. That is because GitHub is looking for [comma, then tab-delimitation](https://help.github.com/articles/rendering-csv-and-tsv-data/), while the file uses `;`-delimitation. The rendering therefor fails on the first comma it encounters (line 39).

I've updated the file to use comma-separation and quotes to escape strings with comma. Tab-delimitation would have been more convenient, but GitHub seems to look for commas first.

The resulting file might be somewhat less easy to update (because you need to quote certain strings), but it is a lot easier to read. As GitHub seems to be the main platform to consume this file, I think it's worth it.
